### PR TITLE
[FIX-#740] Fixed bug in IDPosteriorErrorProbability

### DIFF
--- a/src/tests/topp/IDPosteriorErrorProbability_Mascot_input.idXML
+++ b/src/tests/topp/IDPosteriorErrorProbability_Mascot_input.idXML
@@ -148,5 +148,14 @@
 				<UserParam type="float" name="EValue" value="2.39883291902e-07"/>
 			</PeptideHit>
 		</PeptideIdentification>
+		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="13" MZ="417.1908" RT="2289.66040039063" >
+			<PeptideHit score="0" sequence="(Acetyl)MNELN(Deamidated)Q(Deamidated)EISK" charge="3" protein_refs="PH_9" >
+				<UserParam type="float" name="homology_threshold" value="13"/>
+				<UserParam type="float" name="identity_threshold" value="13"/>
+				<UserParam type="float" name="EValue" value="1e+099"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="protein_references" value="non-unique"/>
+			</PeptideHit>
+		</PeptideIdentification>
 	</IdentificationRun>
 </IdXML>

--- a/src/tests/topp/IDPosteriorErrorProbability_Mascot_input2.idXML
+++ b/src/tests/topp/IDPosteriorErrorProbability_Mascot_input2.idXML
@@ -248,5 +248,14 @@
 				<UserParam type="float" name="EValue" value="2.39883291902e-07"/>
 			</PeptideHit>
 		</PeptideIdentification>
+		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="13" MZ="417.1908" RT="2289.66040039063" >
+			<PeptideHit score="0" sequence="(Acetyl)MNELN(Deamidated)Q(Deamidated)EISK" charge="3" protein_refs="PH_9" >
+				<UserParam type="float" name="homology_threshold" value="13"/>
+				<UserParam type="float" name="identity_threshold" value="13"/>
+				<UserParam type="float" name="EValue" value="1e+099"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="protein_references" value="non-unique"/>
+			</PeptideHit>
+		</PeptideIdentification>
 	</IdentificationRun>
 </IdXML>

--- a/src/tests/topp/IDPosteriorErrorProbability_Mascot_output.idXML
+++ b/src/tests/topp/IDPosteriorErrorProbability_Mascot_output.idXML
@@ -33,19 +33,19 @@
 			</ProteinHit>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="15" MZ="300.164093" RT="1437.53" >
-			<PeptideHit score="0.999999883415763" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_3" >
+			<PeptideHit score="0.999999785304443" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_3" >
 				<UserParam type="float" name="homology_threshold" value="15"/>
 				<UserParam type="float" name="identity_threshold" value="22"/>
 				<UserParam type="float" name="EValue" value="0.79432823472"/>
 				<UserParam type="float" name="Mascot_score" value="14.45"/>
 			</PeptideHit>
-			<PeptideHit score="0.999998276603375" sequence="WSDLHLK" charge="3" >
+			<PeptideHit score="0.99999819974658" sequence="WSDLHLK" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="15"/>
 				<UserParam type="float" name="identity_threshold" value="22"/>
 				<UserParam type="float" name="EValue" value="0.34673685045"/>
 				<UserParam type="float" name="Mascot_score" value="1.64"/>
 			</PeptideHit>
-			<PeptideHit score="0.99999757832529" sequence="GPFAHELK" charge="3" >
+			<PeptideHit score="0.999997473660338" sequence="GPFAHELK" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="15"/>
 				<UserParam type="float" name="identity_threshold" value="22"/>
 				<UserParam type="float" name="EValue" value="0.30199517204"/>
@@ -53,37 +53,37 @@
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="19" MZ="300.678009" RT="1575.38" >
-			<PeptideHit score="0.999983025274228" sequence="VSAAPR" charge="2" >
+			<PeptideHit score="0.999982425828472" sequence="VSAAPR" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="19"/>
 				<UserParam type="float" name="identity_threshold" value="20"/>
 				<UserParam type="float" name="EValue" value="0.13182567386"/>
 				<UserParam type="float" name="Mascot_score" value="11.41"/>
 			</PeptideHit>
-			<PeptideHit score="0.999838254056319" sequence="LSGAPR" charge="2" >
+			<PeptideHit score="0.999834037573364" sequence="LSGAPR" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="19"/>
 				<UserParam type="float" name="identity_threshold" value="20"/>
 				<UserParam type="float" name="EValue" value="0.0457088189615"/>
 				<UserParam type="float" name="Mascot_score" value="5.92"/>
 			</PeptideHit>
-			<PeptideHit score="0.99977725149802" sequence="LSQPR" charge="2" >
+			<PeptideHit score="0.999771739797667" sequence="LSQPR" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="19"/>
 				<UserParam type="float" name="identity_threshold" value="20"/>
 				<UserParam type="float" name="EValue" value="0.0389045144994"/>
 				<UserParam type="float" name="Mascot_score" value="5.83"/>
 			</PeptideHit>
-			<PeptideHit score="0.996024473032848" sequence="GSAIPR" charge="2" >
+			<PeptideHit score="0.995956777214001" sequence="GSAIPR" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="19"/>
 				<UserParam type="float" name="identity_threshold" value="20"/>
 				<UserParam type="float" name="EValue" value="0.00851138038202"/>
 				<UserParam type="float" name="Mascot_score" value="1.17"/>
 			</PeptideHit>
-			<PeptideHit score="0.995853509283039" sequence="GSAPLR" charge="2" >
+			<PeptideHit score="0.995782948548683" sequence="GSAPLR" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="19"/>
 				<UserParam type="float" name="identity_threshold" value="20"/>
 				<UserParam type="float" name="EValue" value="0.00831763771103"/>
 				<UserParam type="float" name="Mascot_score" value="1.17"/>
 			</PeptideHit>
-			<PeptideHit score="0.994207376231092" sequence="LTGGPR" charge="2" >
+			<PeptideHit score="0.994108866870588" sequence="LTGGPR" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="19"/>
 				<UserParam type="float" name="identity_threshold" value="20"/>
 				<UserParam type="float" name="EValue" value="0.00691830970919"/>
@@ -91,7 +91,7 @@
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="13" MZ="301.8590088" RT="1754.8" >
-			<PeptideHit score="0.993165620138674" sequence="TKIPAVFK" charge="3" >
+			<PeptideHit score="0.99304910422502" sequence="TKIPAVFK" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="0"/>
 				<UserParam type="float" name="identity_threshold" value="13"/>
 				<UserParam type="float" name="EValue" value="0.0063095734448"/>
@@ -99,7 +99,7 @@
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="16" MZ="303.184845" RT="1777.58" >
-			<PeptideHit score="0.923252312913514" sequence="MIFAGIKK" charge="3" >
+			<PeptideHit score="0.921732364384241" sequence="MIFAGIKK" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="0"/>
 				<UserParam type="float" name="identity_threshold" value="16"/>
 				<UserParam type="float" name="EValue" value="0.00144543977075"/>
@@ -107,7 +107,7 @@
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="13" MZ="304.180542" RT="1485.47" >
-			<PeptideHit score="0.475573336725897" sequence="LTGQAKHR" charge="3" >
+			<PeptideHit score="0.467753353109561" sequence="LTGQAKHR" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="13"/>
 				<UserParam type="float" name="identity_threshold" value="21"/>
 				<UserParam type="float" name="EValue" value="0.000223872113857"/>
@@ -115,57 +115,67 @@
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="19" MZ="307.4929504" RT="1417.29" >
-			<PeptideHit score="0.22010739556986" sequence="RM(Oxidation)EALER" charge="3" >
+			<PeptideHit score="0.213570424930398" sequence="RM(Oxidation)EALER" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="0"/>
 				<UserParam type="float" name="identity_threshold" value="19"/>
 				<UserParam type="float" name="EValue" value="7.58577575029e-05"/>
 				<UserParam type="float" name="Mascot_score" value="2.16"/>
 			</PeptideHit>
-			<PeptideHit score="0.113548380029683" sequence="RMELESR" charge="3" >
+			<PeptideHit score="0.109087272603028" sequence="RMELESR" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="19"/>
 				<UserParam type="float" name="identity_threshold" value="19"/>
-				<UserParam type="float" name="EValue" value="3.0199517204e-5"/>
+				<UserParam type="float" name="EValue" value="3.0199517204e-05"/>
 				<UserParam type="float" name="Mascot_score" value="1.45"/>
 			</PeptideHit>
-			<PeptideHit score="0.0896769955952511" sequence="TMLASGNAR" charge="3" >
+			<PeptideHit score="0.0858443442925681" sequence="TMLASGNAR" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="19"/>
 				<UserParam type="float" name="identity_threshold" value="19"/>
-				<UserParam type="float" name="EValue" value="2.08929613085e-5"/>
+				<UserParam type="float" name="EValue" value="2.08929613085e-05"/>
 				<UserParam type="float" name="Mascot_score" value="0.46"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="13" MZ="308.5265198" RT="1374.39" >
-			<PeptideHit score="0.0600746990896581" sequence="IIAPPERK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_9" >
+			<PeptideHit score="0.0571143906677382" sequence="IIAPPERK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_9" >
 				<UserParam type="float" name="homology_threshold" value="0"/>
 				<UserParam type="float" name="identity_threshold" value="13"/>
-				<UserParam type="float" name="EValue" value="1e-5"/>
+				<UserParam type="float" name="EValue" value="1e-05"/>
 				<UserParam type="float" name="Mascot_score" value="21.2"/>
 			</PeptideHit>
-			<PeptideHit score="0.0431466860370726" sequence="LPSAPLAVR" charge="3" >
+			<PeptideHit score="0.0407120830996348" sequence="LPSAPLAVR" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="13"/>
 				<UserParam type="float" name="identity_threshold" value="13"/>
-				<UserParam type="float" name="EValue" value="4.78630092323e-6"/>
+				<UserParam type="float" name="EValue" value="4.78630092323e-06"/>
 				<UserParam type="float" name="Mascot_score" value="5.7"/>
 			</PeptideHit>
-			<PeptideHit score="0.0295759434044722" sequence="ISPPAALVR" charge="3" >
+			<PeptideHit score="0.0276687094058081" sequence="ISPPAALVR" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="13"/>
 				<UserParam type="float" name="identity_threshold" value="13"/>
-				<UserParam type="float" name="EValue" value="2.08929613085e-6"/>
+				<UserParam type="float" name="EValue" value="2.08929613085e-06"/>
 				<UserParam type="float" name="Mascot_score" value="5.25"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="15" MZ="309.1685791" RT="3449.33" >
-			<PeptideHit score="0.0226703007993219" sequence="LHQSDVAR" charge="3" >
+			<PeptideHit score="0.0210845619543114" sequence="LHQSDVAR" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="15"/>
 				<UserParam type="float" name="identity_threshold" value="26"/>
-				<UserParam type="float" name="EValue" value="1.17489755494e-6"/>
+				<UserParam type="float" name="EValue" value="1.17489755494e-06"/>
 				<UserParam type="float" name="Mascot_score" value="17.01"/>
 			</PeptideHit>
-			<PeptideHit score="0.0107736878595685" sequence="AAGHAKGSAR" charge="3" >
+			<PeptideHit score="0.00986319905008386" sequence="AAGHAKGSAR" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="15"/>
 				<UserParam type="float" name="identity_threshold" value="26"/>
 				<UserParam type="float" name="EValue" value="2.39883291902e-07"/>
 				<UserParam type="float" name="Mascot_score" value="1.93"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="13" MZ="417.1908" RT="2289.66040039063" >
+			<PeptideHit score="1" sequence="(Acetyl)MNELN(Deamidated)Q(Deamidated)EISK" charge="3" protein_refs="PH_9" >
+				<UserParam type="float" name="homology_threshold" value="13"/>
+				<UserParam type="float" name="identity_threshold" value="13"/>
+				<UserParam type="float" name="EValue" value="1e+99"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="protein_references" value="non-unique"/>
+				<UserParam type="float" name="Mascot_score" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
 	</IdentificationRun>

--- a/src/tests/topp/IDPosteriorErrorProbability_Mascot_output2.idXML
+++ b/src/tests/topp/IDPosteriorErrorProbability_Mascot_output2.idXML
@@ -33,37 +33,37 @@
 			</ProteinHit>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="15" MZ="300.164093" RT="1437.53" >
-			<PeptideHit score="0.999999883415763" sequence="LC(Carbamidomethyl)VLHEK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_3" >
+			<PeptideHit score="0.999999785304443" sequence="LC(Carbamidomethyl)VLHEK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_3" >
 				<UserParam type="float" name="homology_threshold" value="15"/>
 				<UserParam type="float" name="identity_threshold" value="22"/>
 				<UserParam type="float" name="EValue" value="0.79432823472"/>
 				<UserParam type="float" name="Mascot_score" value="14.45"/>
 			</PeptideHit>
-			<PeptideHit score="0.999999883415763" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_3" >
+			<PeptideHit score="0.999999785304443" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_3" >
 				<UserParam type="float" name="homology_threshold" value="15"/>
 				<UserParam type="float" name="identity_threshold" value="22"/>
 				<UserParam type="float" name="EValue" value="0.79432823472"/>
 				<UserParam type="float" name="Posterior Error Probability_score" value="14.45"/>
 			</PeptideHit>
-			<PeptideHit score="0.999998276603375" sequence="WSDLHLK" charge="2" >
+			<PeptideHit score="0.99999819974658" sequence="WSDLHLK" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="15"/>
 				<UserParam type="float" name="identity_threshold" value="22"/>
 				<UserParam type="float" name="EValue" value="0.34673685045"/>
 				<UserParam type="float" name="Mascot_score" value="1.64"/>
 			</PeptideHit>
-			<PeptideHit score="0.999998276603375" sequence="WSDLHLK" charge="3" >
+			<PeptideHit score="0.99999819974658" sequence="WSDLHLK" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="15"/>
 				<UserParam type="float" name="identity_threshold" value="22"/>
 				<UserParam type="float" name="EValue" value="0.34673685045"/>
 				<UserParam type="float" name="Posterior Error Probability_score" value="1.64"/>
 			</PeptideHit>
-			<PeptideHit score="0.99999757832529" sequence="GPFAHELK" charge="2" >
+			<PeptideHit score="0.999997473660338" sequence="GPFAHELK" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="15"/>
 				<UserParam type="float" name="identity_threshold" value="22"/>
 				<UserParam type="float" name="EValue" value="0.30199517204"/>
 				<UserParam type="float" name="Mascot_score" value="0.43"/>
 			</PeptideHit>
-			<PeptideHit score="0.99999757832529" sequence="GPFAHELK" charge="3" >
+			<PeptideHit score="0.999997473660338" sequence="GPFAHELK" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="15"/>
 				<UserParam type="float" name="identity_threshold" value="22"/>
 				<UserParam type="float" name="EValue" value="0.30199517204"/>
@@ -71,73 +71,73 @@
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="19" MZ="300.678009" RT="1575.38" >
-			<PeptideHit score="0.999983025274228" sequence="VSAAPR" charge="2" >
+			<PeptideHit score="0.999982425828472" sequence="VSAAPR" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="19"/>
 				<UserParam type="float" name="identity_threshold" value="20"/>
 				<UserParam type="float" name="EValue" value="0.13182567386"/>
 				<UserParam type="float" name="Mascot_score" value="11.41"/>
 			</PeptideHit>
-			<PeptideHit score="0.999983025274228" sequence="VSAAPR" charge="3" >
+			<PeptideHit score="0.999982425828472" sequence="VSAAPR" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="19"/>
 				<UserParam type="float" name="identity_threshold" value="20"/>
 				<UserParam type="float" name="EValue" value="0.13182567386"/>
 				<UserParam type="float" name="Posterior Error Probability_score" value="11.41"/>
 			</PeptideHit>
-			<PeptideHit score="0.99977725149802" sequence="LSGAPR" charge="2" >
+			<PeptideHit score="0.999834037573364" sequence="LSGAPR" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="19"/>
 				<UserParam type="float" name="identity_threshold" value="20"/>
 				<UserParam type="float" name="EValue" value="0.0457088189615"/>
 				<UserParam type="float" name="Mascot_score" value="5.92"/>
 			</PeptideHit>
-			<PeptideHit score="0.99977725149802" sequence="LSGAPR" charge="3" >
+			<PeptideHit score="0.999834037573364" sequence="LSGAPR" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="19"/>
 				<UserParam type="float" name="identity_threshold" value="20"/>
 				<UserParam type="float" name="EValue" value="0.0457088189615"/>
 				<UserParam type="float" name="Posterior Error Probability_score" value="5.92"/>
 			</PeptideHit>
-			<PeptideHit score="0.99977725149802" sequence="LSQPR" charge="2" >
+			<PeptideHit score="0.999771739797667" sequence="LSQPR" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="19"/>
 				<UserParam type="float" name="identity_threshold" value="20"/>
 				<UserParam type="float" name="EValue" value="0.0389045144994"/>
 				<UserParam type="float" name="Mascot_score" value="5.83"/>
 			</PeptideHit>
-			<PeptideHit score="0.99977725149802" sequence="LSQPR" charge="3" >
+			<PeptideHit score="0.999771739797667" sequence="LSQPR" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="19"/>
 				<UserParam type="float" name="identity_threshold" value="20"/>
 				<UserParam type="float" name="EValue" value="0.0389045144994"/>
 				<UserParam type="float" name="Posterior Error Probability_score" value="5.83"/>
 			</PeptideHit>
-			<PeptideHit score="0.996024473032848" sequence="GSAIPR" charge="2" >
+			<PeptideHit score="0.995956777214001" sequence="GSAIPR" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="19"/>
 				<UserParam type="float" name="identity_threshold" value="20"/>
 				<UserParam type="float" name="EValue" value="0.00851138038202"/>
 				<UserParam type="float" name="Mascot_score" value="1.17"/>
 			</PeptideHit>
-			<PeptideHit score="0.996024473032848" sequence="GSAIPR" charge="3" >
+			<PeptideHit score="0.995956777214001" sequence="GSAIPR" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="19"/>
 				<UserParam type="float" name="identity_threshold" value="20"/>
 				<UserParam type="float" name="EValue" value="0.00851138038202"/>
 				<UserParam type="float" name="Posterior Error Probability_score" value="1.17"/>
 			</PeptideHit>
-			<PeptideHit score="0.995853509283039" sequence="GSAPLR" charge="2" >
+			<PeptideHit score="0.995782948548683" sequence="GSAPLR" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="19"/>
 				<UserParam type="float" name="identity_threshold" value="20"/>
 				<UserParam type="float" name="EValue" value="0.00831763771103"/>
 				<UserParam type="float" name="Mascot_score" value="1.17"/>
 			</PeptideHit>
-			<PeptideHit score="0.995853509283039" sequence="GSAPLR" charge="3" >
+			<PeptideHit score="0.995782948548683" sequence="GSAPLR" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="19"/>
 				<UserParam type="float" name="identity_threshold" value="20"/>
 				<UserParam type="float" name="EValue" value="0.00831763771103"/>
 				<UserParam type="float" name="Posterior Error Probability_score" value="1.17"/>
 			</PeptideHit>
-			<PeptideHit score="0.994207376231092" sequence="LTGGPR" charge="2" >
+			<PeptideHit score="0.994108866870588" sequence="LTGGPR" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="19"/>
 				<UserParam type="float" name="identity_threshold" value="20"/>
 				<UserParam type="float" name="EValue" value="0.00691830970919"/>
 				<UserParam type="float" name="Mascot_score" value="0.91"/>
 			</PeptideHit>
-			<PeptideHit score="0.994207376231092" sequence="LTGGPR" charge="3" >
+			<PeptideHit score="0.994108866870588" sequence="LTGGPR" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="19"/>
 				<UserParam type="float" name="identity_threshold" value="20"/>
 				<UserParam type="float" name="EValue" value="0.00691830970919"/>
@@ -145,13 +145,13 @@
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="13" MZ="301.8590088" RT="1754.8" >
-			<PeptideHit score="0.993165620138674" sequence="TKIPAVFK" charge="2" >
+			<PeptideHit score="0.99304910422502" sequence="TKIPAVFK" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="0"/>
 				<UserParam type="float" name="identity_threshold" value="13"/>
 				<UserParam type="float" name="EValue" value="0.0063095734448"/>
 				<UserParam type="float" name="Mascot_score" value="18.76"/>
 			</PeptideHit>
-			<PeptideHit score="0.993165620138674" sequence="TKIPAVFK" charge="3" >
+			<PeptideHit score="0.99304910422502" sequence="TKIPAVFK" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="0"/>
 				<UserParam type="float" name="identity_threshold" value="13"/>
 				<UserParam type="float" name="EValue" value="0.0063095734448"/>
@@ -159,13 +159,13 @@
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="16" MZ="303.184845" RT="1777.58" >
-			<PeptideHit score="0.923252312913514" sequence="MIFAGIKK" charge="2" >
+			<PeptideHit score="0.921732364384241" sequence="MIFAGIKK" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="0"/>
 				<UserParam type="float" name="identity_threshold" value="16"/>
 				<UserParam type="float" name="EValue" value="0.00144543977075"/>
 				<UserParam type="float" name="Mascot_score" value="31.53"/>
 			</PeptideHit>
-			<PeptideHit score="0.923252312913514" sequence="MIFAGIKK" charge="3" >
+			<PeptideHit score="0.921732364384241" sequence="MIFAGIKK" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="0"/>
 				<UserParam type="float" name="identity_threshold" value="16"/>
 				<UserParam type="float" name="EValue" value="0.00144543977075"/>
@@ -173,13 +173,13 @@
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="13" MZ="304.180542" RT="1485.47" >
-			<PeptideHit score="0.475573336725897" sequence="LTGQAKHR" charge="2" >
+			<PeptideHit score="0.467753353109561" sequence="LTGQAKHR" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="13"/>
 				<UserParam type="float" name="identity_threshold" value="21"/>
 				<UserParam type="float" name="EValue" value="0.000223872113857"/>
 				<UserParam type="float" name="Mascot_score" value="0.45"/>
 			</PeptideHit>
-			<PeptideHit score="0.475573336725897" sequence="LTGQAKHR" charge="3" >
+			<PeptideHit score="0.467753353109561" sequence="LTGQAKHR" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="13"/>
 				<UserParam type="float" name="identity_threshold" value="21"/>
 				<UserParam type="float" name="EValue" value="0.000223872113857"/>
@@ -187,105 +187,115 @@
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="19" MZ="307.4929504" RT="1417.29" >
-			<PeptideHit score="0.22010739556986" sequence="RM(Oxidation)EALER" charge="2" >
+			<PeptideHit score="0.213570424930398" sequence="RM(Oxidation)EALER" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="0"/>
 				<UserParam type="float" name="identity_threshold" value="19"/>
 				<UserParam type="float" name="EValue" value="7.58577575029e-05"/>
 				<UserParam type="float" name="Mascot_score" value="2.16"/>
 			</PeptideHit>
-			<PeptideHit score="0.22010739556986" sequence="RM(Oxidation)EALER" charge="3" >
+			<PeptideHit score="0.213570424930398" sequence="RM(Oxidation)EALER" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="0"/>
 				<UserParam type="float" name="identity_threshold" value="19"/>
 				<UserParam type="float" name="EValue" value="7.58577575029e-05"/>
 				<UserParam type="float" name="Posterior Error Probability_score" value="2.16"/>
 			</PeptideHit>
-			<PeptideHit score="0.113548380029683" sequence="RMELESR" charge="2" >
+			<PeptideHit score="0.109087272603028" sequence="RMELESR" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="19"/>
 				<UserParam type="float" name="identity_threshold" value="19"/>
-				<UserParam type="float" name="EValue" value="3.0199517204e-5"/>
+				<UserParam type="float" name="EValue" value="3.0199517204e-05"/>
 				<UserParam type="float" name="Mascot_score" value="1.45"/>
 			</PeptideHit>
-			<PeptideHit score="0.113548380029683" sequence="RMELESR" charge="3" >
+			<PeptideHit score="0.109087272603028" sequence="RMELESR" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="19"/>
 				<UserParam type="float" name="identity_threshold" value="19"/>
-				<UserParam type="float" name="EValue" value="3.0199517204e-5"/>
+				<UserParam type="float" name="EValue" value="3.0199517204e-05"/>
 				<UserParam type="float" name="Posterior Error Probability_score" value="1.45"/>
 			</PeptideHit>
-			<PeptideHit score="0.0896769955952511" sequence="TMLASGNAR" charge="2" >
+			<PeptideHit score="0.0858443442925681" sequence="TMLASGNAR" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="19"/>
 				<UserParam type="float" name="identity_threshold" value="19"/>
-				<UserParam type="float" name="EValue" value="2.08929613085e-5"/>
+				<UserParam type="float" name="EValue" value="2.08929613085e-05"/>
 				<UserParam type="float" name="Mascot_score" value="0.46"/>
 			</PeptideHit>
-			<PeptideHit score="0.0896769955952511" sequence="TMLASGNAR" charge="3" >
+			<PeptideHit score="0.0858443442925681" sequence="TMLASGNAR" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="19"/>
 				<UserParam type="float" name="identity_threshold" value="19"/>
-				<UserParam type="float" name="EValue" value="2.08929613085e-5"/>
+				<UserParam type="float" name="EValue" value="2.08929613085e-05"/>
 				<UserParam type="float" name="Posterior Error Probability_score" value="0.46"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="13" MZ="308.5265198" RT="1374.39" >
-			<PeptideHit score="0.0600746990896581" sequence="IIAPPERK" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_9" >
+			<PeptideHit score="0.0571143906677382" sequence="IIAPPERK" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_9" >
 				<UserParam type="float" name="homology_threshold" value="0"/>
 				<UserParam type="float" name="identity_threshold" value="13"/>
-				<UserParam type="float" name="EValue" value="1e-5"/>
+				<UserParam type="float" name="EValue" value="1e-05"/>
 				<UserParam type="float" name="Mascot_score" value="21.2"/>
 			</PeptideHit>
-			<PeptideHit score="0.0600746990896581" sequence="IIAPPERK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_9" >
+			<PeptideHit score="0.0571143906677382" sequence="IIAPPERK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_9" >
 				<UserParam type="float" name="homology_threshold" value="0"/>
 				<UserParam type="float" name="identity_threshold" value="13"/>
-				<UserParam type="float" name="EValue" value="1e-5"/>
+				<UserParam type="float" name="EValue" value="1e-05"/>
 				<UserParam type="float" name="Posterior Error Probability_score" value="21.2"/>
 			</PeptideHit>
-			<PeptideHit score="0.0431466860370726" sequence="LPSAPLAVR" charge="2" >
+			<PeptideHit score="0.0407120830996348" sequence="LPSAPLAVR" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="13"/>
 				<UserParam type="float" name="identity_threshold" value="13"/>
-				<UserParam type="float" name="EValue" value="4.78630092323e-6"/>
+				<UserParam type="float" name="EValue" value="4.78630092323e-06"/>
 				<UserParam type="float" name="Mascot_score" value="5.7"/>
 			</PeptideHit>
-			<PeptideHit score="0.0431466860370726" sequence="LPSAPLAVR" charge="3" >
+			<PeptideHit score="0.0407120830996348" sequence="LPSAPLAVR" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="13"/>
 				<UserParam type="float" name="identity_threshold" value="13"/>
-				<UserParam type="float" name="EValue" value="4.78630092323e-6"/>
+				<UserParam type="float" name="EValue" value="4.78630092323e-06"/>
 				<UserParam type="float" name="Posterior Error Probability_score" value="5.7"/>
 			</PeptideHit>
-			<PeptideHit score="0.0295759434044722" sequence="ISPPAALVR" charge="2" >
+			<PeptideHit score="0.0276687094058081" sequence="ISPPAALVR" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="13"/>
 				<UserParam type="float" name="identity_threshold" value="13"/>
-				<UserParam type="float" name="EValue" value="2.08929613085e-6"/>
+				<UserParam type="float" name="EValue" value="2.08929613085e-06"/>
 				<UserParam type="float" name="Mascot_score" value="5.25"/>
 			</PeptideHit>
-			<PeptideHit score="0.0295759434044722" sequence="ISPPAALVR" charge="3" >
+			<PeptideHit score="0.0276687094058081" sequence="ISPPAALVR" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="13"/>
 				<UserParam type="float" name="identity_threshold" value="13"/>
-				<UserParam type="float" name="EValue" value="2.08929613085e-6"/>
+				<UserParam type="float" name="EValue" value="2.08929613085e-06"/>
 				<UserParam type="float" name="Posterior Error Probability_score" value="5.25"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="15" MZ="309.1685791" RT="3449.33" >
-			<PeptideHit score="0.0226703007993219" sequence="LHQSDVAR" charge="2" >
+			<PeptideHit score="0.0210845619543114" sequence="LHQSDVAR" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="15"/>
 				<UserParam type="float" name="identity_threshold" value="26"/>
-				<UserParam type="float" name="EValue" value="1.17489755494e-6"/>
+				<UserParam type="float" name="EValue" value="1.17489755494e-06"/>
 				<UserParam type="float" name="Mascot_score" value="17.01"/>
 			</PeptideHit>
-			<PeptideHit score="0.0226703007993219" sequence="LHQSDVAR" charge="3" >
+			<PeptideHit score="0.0210845619543114" sequence="LHQSDVAR" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="15"/>
 				<UserParam type="float" name="identity_threshold" value="26"/>
-				<UserParam type="float" name="EValue" value="1.17489755494e-6"/>
+				<UserParam type="float" name="EValue" value="1.17489755494e-06"/>
 				<UserParam type="float" name="Posterior Error Probability_score" value="17.01"/>
 			</PeptideHit>
-			<PeptideHit score="0.0107736878595685" sequence="AAGHAKGSAR" charge="2" >
+			<PeptideHit score="0.00986319905008386" sequence="AAGHAKGSAR" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="15"/>
 				<UserParam type="float" name="identity_threshold" value="26"/>
 				<UserParam type="float" name="EValue" value="2.39883291902e-07"/>
 				<UserParam type="float" name="Mascot_score" value="1.93"/>
 			</PeptideHit>
-			<PeptideHit score="0.0107736878595685" sequence="AAGHAKGSAR" charge="3" >
+			<PeptideHit score="0.00986319905008386" sequence="AAGHAKGSAR" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="15"/>
 				<UserParam type="float" name="identity_threshold" value="26"/>
 				<UserParam type="float" name="EValue" value="2.39883291902e-07"/>
 				<UserParam type="float" name="Posterior Error Probability_score" value="1.93"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="13" MZ="417.1908" RT="2289.66040039063" >
+			<PeptideHit score="1" sequence="(Acetyl)MNELN(Deamidated)Q(Deamidated)EISK" charge="3" protein_refs="PH_9" >
+				<UserParam type="float" name="homology_threshold" value="13"/>
+				<UserParam type="float" name="identity_threshold" value="13"/>
+				<UserParam type="float" name="EValue" value="1e+99"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="protein_references" value="non-unique"/>
+				<UserParam type="float" name="Posterior Error Probability_score" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
 	</IdentificationRun>

--- a/src/topp/IDPosteriorErrorProbability.cpp
+++ b/src/topp/IDPosteriorErrorProbability.cpp
@@ -159,10 +159,10 @@ protected:
     }
     else if (engine == "MASCOT")
     {
-      // bug #740: unable to fit data with score 0. Set score to NaN and ignore the score
+      // bug #740: unable to fit data with score 0
       if (hit.getScore() == 0) 
       {
-	return numeric_limits<double>::quiet_NaN();
+        return numeric_limits<double>::quiet_NaN();
       }
       // end bug #740
       if (hit.metaValueExists("EValue"))
@@ -280,27 +280,23 @@ protected:
                 {
                   if (!hits.empty() && (!split_charge || hits[0].getCharge() == *charge))
                   {
-		    DoubleReal score = get_score_(*engine, hits[0]);
-		    if (score != score) // NaN check, #740: ignore scores with 0 values, otherwise you will get the error: unable to fit data
-		    {
-		      score = 1;
-		    }
-                    else 
-		    {
-		      scores.push_back(score);
+                    DoubleReal score = get_score_(*engine, hits[0]);
+                    if (score == score) // NaN check, #740: ignore scores with 0 values, otherwise you will get the error: unable to fit data
+                    {
+                      scores.push_back(score);
 
-		      if (target_decoy_available)
-		      {
-			if (hits[0].getScore() < fdr_for_targets_smaller)
-			{
-			  target.push_back(score);
-			}
-			else
-			{
-			  decoy.push_back(score);
-			}
-		      }
-		    }
+                      if (target_decoy_available)
+                      {
+                        if (hits[0].getScore() < fdr_for_targets_smaller)
+                        {
+                          target.push_back(score);
+                        }
+                        else
+                        {
+                          decoy.push_back(score);
+                        }
+                      }
+                    }
                   }
                 }
                 else
@@ -309,15 +305,11 @@ protected:
                   {
                     if (!split_charge || hit->getCharge() == *charge)
                     {
-		      DoubleReal score = get_score_(*engine, *hit);
-		      if (score != score) // NaN check, #740: ignore scores with 0 values, otherwise you will get the error: unable to fit data
-		      {
-			score = 1;
-		      }
-		      else
-		      {
-			scores.push_back(score);
-		      }
+                      DoubleReal score = get_score_(*engine, *hit);
+                      if (score == score) // NaN check, #740: ignore scores with 0 values, otherwise you will get the error: unable to fit data
+                      {
+                        scores.push_back(score);
+                      }
                     }
                   }
                 }
@@ -390,7 +382,7 @@ protected:
 
         bool unable_to_fit_data = true;
         bool data_might_not_be_well_fit = true;
-	for (vector<ProteinIdentification>::iterator prot_iter = protein_ids.begin(); prot_iter < protein_ids.end(); ++prot_iter)
+        for (vector<ProteinIdentification>::iterator prot_iter = protein_ids.begin(); prot_iter < protein_ids.end(); ++prot_iter)
         {
           String searchengine_toUpper =  prot_iter->getSearchEngine();
           searchengine_toUpper.toUpper();
@@ -410,17 +402,17 @@ protected:
                     DoubleReal score;
                     hit->setMetaValue(score_type, hit->getScore());
 
-		    score = get_score_(engine, *hit);
-		    if (score != score) // NaN check, #740: ignore scores with 0 values, otherwise you will get the error: unable to fit data
-		    {
-		      score = 1;
-		    }
-		    else 
-		    { 
-		      score = PEP_model.computeProbability(score);
-		      if (score > 0 && score < 1) unable_to_fit_data = false;  //only if all it->second[0] are 0 or 1 unable_to_fit_data stays true
-		      if (score > 0.2 && score < 0.8) data_might_not_be_well_fit = false;  //same as above
-		    }
+                    score = get_score_(engine, *hit);
+                    if (score != score) // NaN check, #740: ignore scores with 0 values, otherwise you will get the error: unable to fit data
+                    {
+                      score = 1;
+                    }
+                    else 
+                    { 
+                      score = PEP_model.computeProbability(score);
+                      if (score > 0 && score < 1) unable_to_fit_data = false;  //only if all it->second[0] are 0 or 1 unable_to_fit_data stays true
+                      if (score > 0.2 && score < 0.8) data_might_not_be_well_fit = false;  //same as above
+                    }
                     hit->setScore(score);
                     if (prob_correct)
                     {

--- a/src/topp/IDPosteriorErrorProbability.cpp
+++ b/src/topp/IDPosteriorErrorProbability.cpp
@@ -159,6 +159,12 @@ protected:
     }
     else if (engine == "MASCOT")
     {
+      // bug #740: unable to fit data with score 0. Set score to NaN and ignore the score
+      if (hit.getScore() == 0) 
+      {
+	return numeric_limits<double>::quiet_NaN();
+      }
+      // end bug #740
       if (hit.metaValueExists("EValue"))
       {
         return (-1) * log10(max((DoubleReal)hit.getMetaValue("EValue"), smallest_e_value_));
@@ -274,18 +280,27 @@ protected:
                 {
                   if (!hits.empty() && (!split_charge || hits[0].getCharge() == *charge))
                   {
-                    scores.push_back(get_score_(*engine, hits[0]));
-                    if (target_decoy_available)
-                    {
-                      if (hits[0].getScore() < fdr_for_targets_smaller)
-                      {
-                        target.push_back(get_score_(*engine, hits[0]));
-                      }
-                      else
-                      {
-                        decoy.push_back(get_score_(*engine, hits[0]));
-                      }
-                    }
+		    DoubleReal score = get_score_(*engine, hits[0]);
+		    if (score != score) // NaN check, #740: ignore scores with 0 values, otherwise you will get the error: unable to fit data
+		    {
+		      score = 1;
+		    }
+                    else 
+		    {
+		      scores.push_back(score);
+
+		      if (target_decoy_available)
+		      {
+			if (hits[0].getScore() < fdr_for_targets_smaller)
+			{
+			  target.push_back(score);
+			}
+			else
+			{
+			  decoy.push_back(score);
+			}
+		      }
+		    }
                   }
                 }
                 else
@@ -294,7 +309,15 @@ protected:
                   {
                     if (!split_charge || hit->getCharge() == *charge)
                     {
-                      scores.push_back(get_score_(*engine, *hit));
+		      DoubleReal score = get_score_(*engine, *hit);
+		      if (score != score) // NaN check, #740: ignore scores with 0 values, otherwise you will get the error: unable to fit data
+		      {
+			score = 1;
+		      }
+		      else
+		      {
+			scores.push_back(score);
+		      }
                     }
                   }
                 }
@@ -334,6 +357,7 @@ protected:
       writeLog_("No data collected. Check whether search engine is supported.");
       if (!ignore_bad_data) return INPUT_FILE_EMPTY;
     }
+
     for (map<String, vector<vector<double> > >::iterator it = all_scores.begin(); it != all_scores.end(); ++it)
     {
       vector<String> engine_info;
@@ -352,6 +376,7 @@ protected:
       }
 
       const bool return_value = PEP_model.fit(it->second[0]);
+
       if (!return_value) writeLog_("unable to fit data. Algorithm did not run through for the following search engine: " + engine);
       if (!return_value && !ignore_bad_data) return UNEXPECTED_RESULT;
 
@@ -365,7 +390,7 @@ protected:
 
         bool unable_to_fit_data = true;
         bool data_might_not_be_well_fit = true;
-        for (vector<ProteinIdentification>::iterator prot_iter = protein_ids.begin(); prot_iter < protein_ids.end(); ++prot_iter)
+	for (vector<ProteinIdentification>::iterator prot_iter = protein_ids.begin(); prot_iter < protein_ids.end(); ++prot_iter)
         {
           String searchengine_toUpper =  prot_iter->getSearchEngine();
           searchengine_toUpper.toUpper();
@@ -384,9 +409,18 @@ protected:
                   {
                     DoubleReal score;
                     hit->setMetaValue(score_type, hit->getScore());
-                    score = PEP_model.computeProbability(get_score_(engine, *hit));
-                    if (score > 0 && score < 1) unable_to_fit_data = false;  //only if all it->second[0] are 0 or 1 unable_to_fit_data stays true
-                    if (score > 0.2 && score < 0.8) data_might_not_be_well_fit = false;  //same as above
+
+		    score = get_score_(engine, *hit);
+		    if (score != score) // NaN check, #740: ignore scores with 0 values, otherwise you will get the error: unable to fit data
+		    {
+		      score = 1;
+		    }
+		    else 
+		    { 
+		      score = PEP_model.computeProbability(score);
+		      if (score > 0 && score < 1) unable_to_fit_data = false;  //only if all it->second[0] are 0 or 1 unable_to_fit_data stays true
+		      if (score > 0.2 && score < 0.8) data_might_not_be_well_fit = false;  //same as above
+		    }
                     hit->setScore(score);
                     if (prob_correct)
                     {


### PR DESCRIPTION
Peptide with score 0 (e-value 10^99) will be ignored in the model testing and fitting, otherwise the program ends with the error. "unable to fit data. Algorithm did not run through for the following search engine: MASCOT".
The score 0 only will be ignored by a mascot search. To check if the changes are correct, I extended the Testfiles IDPosteriorErrorProbability_Mascot_input, IDPosteriorErrorProbability_Mascot_input2 with a PeptideIdentification that includes a PeptideHit which has the score=0 and e-value=1e+099 and created new output files for comparison. All tests for IDPosteriorErrorProbability were successful. 
