### PR TITLE
Rna lfq ambivar

### DIFF
--- a/src/pyOpenMS/pxds/NucleicAcidSpectrumGenerator.pxd
+++ b/src/pyOpenMS/pxds/NucleicAcidSpectrumGenerator.pxd
@@ -1,0 +1,19 @@
+from Types cimport *
+from libcpp.map cimport map as libcpp_map
+from libcpp.set cimport set as libcpp_set
+from DefaultParamHandler cimport *
+from MSSpectrum cimport *
+from DataArrays cimport *
+from NASequence cimport *
+
+cdef extern from "<OpenMS/CHEMISTRY/NucleicAcidSpectrumGenerator.h>" namespace "OpenMS":
+
+    cdef cppclass NucleicAcidSpectrumGenerator(DefaultParamHandler) :
+        # wrap-inherits:
+        #  DefaultParamHandler
+        NucleicAcidSpectrumGenerator() nogil except +
+        NucleicAcidSpectrumGenerator(NucleicAcidSpectrumGenerator) nogil except +
+        void getSpectrum(MSSpectrum & spectrum, NASequence & oligo, Int min_charge, Int max_charge) nogil except +
+        # void getMultipleSpectra(libcpp_map[ Int, MSSpectrum ] & spectra, NASequence & oligo, libcpp_set[ int ] & charges, Int base_charge) nogil except +
+        void updateMembers_() nogil except +
+

--- a/src/pyOpenMS/pxds/Ribonucleotide.pxd
+++ b/src/pyOpenMS/pxds/Ribonucleotide.pxd
@@ -101,3 +101,6 @@ cdef extern from "<OpenMS/CHEMISTRY/Ribonucleotide.h>" namespace "OpenMS":
 
         # true if the ribonucleotide is a modified one
         bool isModified() nogil except +
+
+        # true if the ribonucleotide is an ambiguous modification
+        bool isAmbiguous() nogil except +

--- a/src/pyOpenMS/pxds/RibonucleotideDB.pxd
+++ b/src/pyOpenMS/pxds/RibonucleotideDB.pxd
@@ -8,6 +8,7 @@ cdef extern from "<OpenMS/CHEMISTRY/RibonucleotideDB.h>" namespace "OpenMS":
         # wrap-manual-memory:
         #   cdef AutowrapPtrHolder[_RibonucleotideDB] inst
 
+        #RibonucleotideDB() nogil except +
         RibonucleotideDB(RibonucleotideDB) nogil except + #wrap-ignore
 
 # COMMENT: wrap static methods

--- a/src/pyOpenMS/pxds/RibonucleotideDB.pxd
+++ b/src/pyOpenMS/pxds/RibonucleotideDB.pxd
@@ -15,3 +15,4 @@ cdef extern from "<OpenMS/CHEMISTRY/RibonucleotideDB.h>" namespace "OpenMS::Ribo
     
     RibonucleotideDB* getInstance() nogil except + # wrap-ignore
 
+    #libcpp_pair[ const Ribonucleotide *, const Ribonucleotide * ] getRibonucleotideAlternatives(libcpp_string & code) nogil except +


### PR DESCRIPTION
I've implemented the low hanging fruit python bindings. RibonucleotideDB getRibonucleotideAlternatives continues to have the issue with the "using ConstRibonucleotidePtr = const Ribonucleotide *;" 